### PR TITLE
Fix composer warning about outdated lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want to contribute to the project.
 
 ## Prerequisites
 
-- PHP ^5.6
+- PHP >=5.6.0
 - [Composer](https://getcomposer.org/)
 - _Optionally_ [NPM](https://www.npmjs.com/get-npm)
 

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "michelf/php-markdown": "^1.8",
         "league/plates": "3.*",
         "jamesmoss/flywheel": "^0.5.2",
-        "php": "^5.6.0",
+        "php": ">=5.6.0",
         "altorouter/altorouter": "^1.2"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "21aa4f4247c76d4a524ea5054aa6f09a",
+    "content-hash": "f9644fc739f56d4f7a89c3050f0771d4",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -226,7 +226,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2"
+        "php": ">=5.6.0"
     },
     "platform-dev": []
 }


### PR DESCRIPTION
Fix warning about outdated lock by setting the correct PHP required version and then regenerating the lock.