### PR TITLE
feat: add unsaved changes' asterix indicator

### DIFF
--- a/app/view/templates/edit.php
+++ b/app/view/templates/edit.php
@@ -29,6 +29,7 @@
 
 <script>
     const pageid = '<?= $page->id() ?>';
+    let pagetitle = '<?= $page->title() ?>';
 </script>
 <script src="<?= Model::jspath() ?>edit.bundle.js"></script>
 </body>

--- a/src/edit.js
+++ b/src/edit.js
@@ -10,9 +10,16 @@ import 'codemirror/addon/search/jump-to-line';
 import 'codemirror/addon/dialog/dialog';
 import 'codemirror/addon/dialog/dialog.css';
 
+/** @type {HTMLFormElement} */
 let form;
+
+/** @type {CodeMirror.EditorFromTextArea[]} */
 let editors = [];
+
+/** @type {boolean} */
 let unsavedChanges = false;
+
+/** @type {InputEvent} */
 const inputEvent = new InputEvent('input');
 
 window.addEventListener('load', () => {
@@ -179,10 +186,10 @@ function confirmExit(e) {
 
 function changed() {
     unsavedChanges = true;
-    document.title = '✏ *' + pageid;
+    document.title = '✏ *' + pagetitle;
 }
 
 function saved() {
     unsavedChanges = false;
-    document.title = '✏ ' + pageid;
+    document.title = '✏ ' + pagetitle;
 }

--- a/src/edit.js
+++ b/src/edit.js
@@ -187,9 +187,11 @@ function confirmExit(e) {
 function changed() {
     unsavedChanges = true;
     document.title = '✏ *' + pagetitle;
+    document.getElementById('headid').innerHTML = '*' + pageid;
 }
 
 function saved() {
     unsavedChanges = false;
     document.title = '✏ ' + pagetitle;
+    document.getElementById('headid').innerHTML = pageid;
 }

--- a/src/edit.js
+++ b/src/edit.js
@@ -92,6 +92,10 @@ window.addEventListener('load', () => {
     fontSizeInput.addEventListener('change', fontSizeChangeHandler);
     fontSizeInput.dispatchEvent(new Event('change'));
 
+    document.getElementById('title').addEventListener('input', e => {
+        pagetitle = e.target.value;
+    });
+
     window.onkeydown = keyboardHandler;
     window.onbeforeunload = confirmExit;
 });

--- a/src/edit.js
+++ b/src/edit.js
@@ -27,6 +27,7 @@ window.addEventListener('load', () => {
         submitHandler(this);
     });
 
+    // disable CodeMirror's default ctrl+D shortcut (delete line)
     delete CodeMirror.keyMap['default']['Ctrl-D'];
 
     editors = [
@@ -127,7 +128,7 @@ function changeHandler(e) {
     ) {
         return;
     }
-    unsavedChanges = true;
+    changed();
 }
 
 /**
@@ -157,8 +158,7 @@ function submitHandler(form) {
     var fd = new FormData(form);
 
     xhr.addEventListener('load', function(event) {
-        unsavedChanges = false;
-        // Add "last update" timestamp here
+        saved();
     });
     xhr.addEventListener('error', function(event) {
         alert('Error while trying to update.');
@@ -175,4 +175,14 @@ function confirmExit(e) {
     if (unsavedChanges) {
         return 'You have unsaved changes, do you really want to leave this page?';
     }
+}
+
+function changed() {
+    unsavedChanges = true;
+    document.title = '✏ *' + pageid;
+}
+
+function saved() {
+    unsavedChanges = false;
+    document.title = '✏ ' + pageid;
 }


### PR DESCRIPTION
Added only asterix. You can easily edit the `changed()` and `saved()` functions to try the emoticon change.

Part of #17 