### PR TITLE
Fix summary rendering

### DIFF
--- a/app/class/Header.php
+++ b/app/class/Header.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Wcms;
+
+/**
+ * Simple "c struct like" class that represent a Header's datas.
+ * All members are public because there is no logic in this class. It is only
+ * used to pass data from one element to another with cleanly typed members.
+ */
+class Header
+{
+	/** @var string $id the id of this header. */
+	public $id;
+	/** @var int $level the level of deepness of this header. */
+	public $level;
+	/** @var string $title the title displayed by this header. */
+	public $title;
+
+	public function __construct(string $id, int $level, string $title) {
+		$this->id = $id;
+		$this->level = $level;
+		$this->title = $title;
+	}
+}

--- a/app/class/Modelrender.php
+++ b/app/class/Modelrender.php
@@ -437,17 +437,15 @@ class Modelrender extends Modelpage
 			$max = 6;
 		}
 
-		$sum = [];
 		$text = preg_replace_callback(
 			'/<h([' . $min . '-' . $max . '])(\s+(\s*\w+="\w+")*)?\s*>(.+)<\/h[' . $min . '-' . $max . ']>/mU',
-			function ($matches) use (&$sum) {
+			function ($matches) {
 				$cleanid = idclean($matches[4]);
-				$sum[$cleanid][$matches[1]] = $matches[4];
+				$this->sum[] = new Header($cleanid, intval($matches[1]), $matches[4]);
 				return '<h' . $matches[1] . $matches[2] . ' id="' . $cleanid . '">' . $matches[4] . '</h' . $matches[1] . '>';
 			},
 			$text
 		);
-		$this->sum[$element] = $sum;
 		return $text;
 	}
 

--- a/app/class/Modelrender.php
+++ b/app/class/Modelrender.php
@@ -438,11 +438,19 @@ class Modelrender extends Modelpage
 		}
 
 		$text = preg_replace_callback(
-			'/<h([' . $min . '-' . $max . '])(\s+(\s*\w+="\w+")*)?\s*>(.+)<\/h[' . $min . '-' . $max . ']>/mU',
+			"/<h([$min-$max])((.*)id=\"([^\"]*)\"(.*)|.*)>(.+)<\/h[$min-$max]>/mU",
 			function ($matches) {
-				$cleanid = idclean($matches[4]);
-				$this->sum[] = new Header($cleanid, intval($matches[1]), $matches[4]);
-				return '<h' . $matches[1] . $matches[2] . ' id="' . $cleanid . '">' . $matches[4] . '</h' . $matches[1] . '>';
+				$level = $matches[1];
+				$beforeid = $matches[3];
+				$id = $matches[4];
+				$afterid = $matches[5];
+				$content = $matches[6];
+				// if no custom id is defined, use idclean of the content as id
+				if (empty($id)) {
+					$id = idclean($content);
+				}
+				$this->sum[] = new Header($id, intval($level), $content);
+				return "<h$level $beforeid id=\"$id\" $afterid>$content</h$level>";
 			},
 			$text
 		);

--- a/app/class/Summary.php
+++ b/app/class/Summary.php
@@ -16,7 +16,7 @@ class Summary extends Item
     /** @var int Maximum summary level*/
     protected $max = 6;
 
-    /** @var array Headers datas */
+    /** @var Header[] Headers datas */
     protected $sum = [];
 
     /** @var string Name of element to display */
@@ -48,46 +48,30 @@ class Summary extends Item
     public function sumparser()
     {
         $sumstring = '';
+        $minlevel = $this->min - 1;
+        $prevlevel = $minlevel;
 
-        
-        foreach ($this->sum as $type => $element) {
-            if(!empty($element) && (empty($this->element) || $type === $this->element)) {
-
-                $filteredsum = [];
-        
-                foreach ($element as $key => $menu) {
-                    $deepness = array_keys($menu)[0];
-                    if($deepness >= $this->min && $deepness <= $this->max) {
-                        $filteredsum[$key] = $menu;
-                    }
-                }
-        
-                $last = 0;
-                foreach ($filteredsum as $title => $list) {
-                    foreach ($list as $h => $link) {
-                        if ($h > $last) {
-                            for ($i = 1; $i <= ($h - $last); $i++) {
-                                $sumstring .= '<ul>' . PHP_EOL;
-                            }
-                            $sumstring .= '<li><a href="#' . $title . '">' . $link . '</a></li>' . PHP_EOL;
-                        } elseif ($h < $last) {
-                            for ($i = 1; $i <= ($last - $h); $i++) {
-                                $sumstring .= '</ul>' . PHP_EOL;
-                            }
-                            $sumstring .= '<li><a href="#' . $title . '">' . $link . '</a></li>' . PHP_EOL;
-                        } elseif ($h = $last) {
-                            $sumstring .= '<li><a href="#' . $title . '">' . $link . '</a></li>' . PHP_EOL;
-                        }
-                        $last = $h;
-                    }
-                }
-                for ($i = 1; $i <= ($last); $i++) {
-                    $sumstring .= '</ul>' . PHP_EOL;
-                }
-
+        foreach ($this->sum as $header) {
+            if ($header->level < $this->min || $header->level > $this->max) {
+                // not in the accepted range, skiping this header.
+                continue;
+            };
+            for ($i = $header->level; $i > $prevlevel; $i--) {
+                $sumstring .= '<ul><li>';
             }
+            for ($i = $header->level; $i < $prevlevel; $i++) {
+                $sumstring .= '</li></ul>';
+            }
+            if ($header->level <= $prevlevel) {
+                $sumstring .= '</li><li>';
+            }
+            $sumstring .= "<a href=\"#$header->id\">$header->title</a>";
+            $prevlevel = $header->level;
         }
-		return $sumstring;
+        for ($i = $minlevel; $i < $prevlevel; $i++) {
+            $sumstring .= "</li></ul>";
+        }
+        return $sumstring;
     }
 
 


### PR DESCRIPTION
This PR fixes 2 issues I had with the SUMMARY of W-cms (#80 and #81)

The summary rendering is not entirely valid yet as `<ul>` element shouldn't be inside `<p>` element. But this is more complicated to fix and browsers fixes it automatically (this is not an excuse, it should still be fixed).