### PR TITLE
fix: un-highlight wsyntax in comments

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -20,6 +20,7 @@ CodeMirror.defineSimpleMode('wcms', {
             token: 'wcms',
             next: 'wcms',
         },
+        { regex: /<!--/, token: 'comment', next: 'comment' },
     ],
     // 'wcms' mode, for each macro, if there is parameters, pass to its associated mode
     wcms: [
@@ -61,6 +62,10 @@ CodeMirror.defineSimpleMode('wcms', {
     media: [
         { regex: /path|sortby|order|type/, token: 'wkeyword', push: 'wcms' },
         { regex: null, push: 'wcms' },
+    ],
+    comment: [
+        { regex: /.*?-->/, token: 'comment', next: 'start' },
+        { regex: /.*/, token: 'comment' },
     ],
 });
 


### PR DESCRIPTION
### before
![image](https://user-images.githubusercontent.com/23519418/79081801-e0abc380-7d20-11ea-884e-4723c1b97a54.png)

### after
![image](https://user-images.githubusercontent.com/23519418/79081805-e99c9500-7d20-11ea-9bfd-e8fe37ad8345.png)
