### PR TITLE
tests: add phpcs with minimal PSR12 config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,10 @@ dist/w_cms_%.zip: all
 		.default.env \
 		.gitignore \
 		.release-it.json \
-		Makefile \
 		"composer*" \
+		Makefile \
 		"package*" \
+		phpcs.xml \
 		webpack.config.js
 
 # Generate the js bundles (and sourcemaps).
@@ -150,6 +151,11 @@ buildclean:
 	rm -rf $(js_bundles)
 	rm -rf $(js_srcmaps)
 	rm -rf $(build_dir)
+
+.PHONY: check
+check:
+	@echo Running tests...
+	phpcs
 
 # Touch files affected by the build environment to force the execution
 # of the corresponding targets.

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {
-        "sentry/sdk": "^2.0"
+        "sentry/sdk": "^2.0",
+        "squizlabs/php_codesniffer": "^3.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "dd0efdb33769c0ca504cbf4478c51fbf",
+    "content-hash": "e099652c0565f5b3cad14bc2132646d6",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -1412,6 +1412,57 @@
                 "sentry"
             ],
             "time": "2019-12-18T08:56:34+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "dceec07328401de6211037abbb18bda423677e26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/dceec07328401de6211037abbb18bda423677e26",
+                "reference": "dceec07328401de6211037abbb18bda423677e26",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards"
+            ],
+            "time": "2020-01-30T22:20:29+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" ?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         name="WRuleset"
+         xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/squizlabs/PHP_CodeSniffer/master/phpcs.xsd">
+    <description>The coding standard for Wcms.</description>
+
+    <!-- included files -->
+    <file>index.php</file>
+    <file>app</file>
+    <exclude-pattern>app/view/templates/*\.php$</exclude-pattern>
+
+    <!-- Add some default command line args (see help) -->
+    <arg name="basepath" value="."/>
+    <arg name="colors" />
+    <arg name="parallel" value="75" />
+    <arg value="p" />
+
+    <!-- Include the whole PSR12 standard -->
+    <rule ref="PSR12"></rule>
+
+    <!-- Add some rules -->
+    <rule ref="Generic.Metrics.NestingLevel"></rule>
+</ruleset>


### PR DESCRIPTION
I added a [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) config with a minimal PSR12 config. I let you run the formater yourself so you can adjust the configuration dy adding or removing some rules. Both are accessible in the `vendor/bin` folder. And I also added a `check` target to make that runs all the tests (only phpcs for now).
![Peek 2020-04-16 22-42](https://user-images.githubusercontent.com/23519418/79504729-a188b580-8033-11ea-8192-19449019eb15.gif)

I recommend that you install [this very good vscode extension](https://marketplace.visualstudio.com/items?itemName=wongjn.php-sniffer) that registers **phpcs** as a Linter and **phpcbf** as a Formater. Then you just have to add the following to you vscode settings.json
```json
"phpSniffer.autoDetect": true
```
![Peek 2020-04-16 22-39](https://user-images.githubusercontent.com/23519418/79504513-4eaefe00-8033-11ea-94d4-54063f2b2142.gif)
