### PR TITLE
Add phpstan

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,0 +1,27 @@
+name: build
+
+on:
+    push:
+        branches: [ master ]
+    pull_request:
+        branches: [ master ]
+
+jobs:
+    php-build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Validate composer.json and composer.lock
+                run: composer validate
+
+            -   name: Install dependencies
+                run: composer install --prefer-dist --no-progress --no-suggest
+
+            # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
+            # Docs: https://getcomposer.org/doc/articles/scripts.md
+
+            -   name: Run test suite
+                run: make check -k

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode/*
 .env
+*.log
 *.bundle.js
 *.bundle.js.map
 assets/render/*

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ dist/w_cms_%.zip: all
 		"package*" \
 		phpcs.xml \
 		phpunit.xml \
+		phpstan.neon \
 		webpack.config.js
 
 # Generate the js bundles (and sourcemaps).
@@ -158,12 +159,17 @@ buildclean:
 
 # Run all checks.
 .PHONY: check
-check: vendor lint test
+check: vendor lint analyse test
 
 # Lint php code with phpcs.
 .PHONY: lint
 lint: $(phpcs_dir)
 	phpcs --report-full --report-checkstyle=$(phpcs_dir)/checkstyle.xml
+
+# Analyse php code with phpstan.
+.PHONY: analyse
+analyse:
+	phpstan analyse
 
 # Test php code with phpunit.
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,8 @@ dist/w_cms_%.zip: all
 	zip -d $@ \
 		"$(js_src_dir)/*" \
 		$(js_srcmaps) \
+		".github*" \
+		tests \
 		.default.env \
 		.gitignore \
 		.release-it.json \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # W-CMS
 
+![github status] ![code style] ![phpstan level]
+
 W is a lightweight CMS tool, meant to help you design a website using a unique approach. It's targeting artists, or experimental projects.
 
 To have a better idea of what W can do, you can check out the [User manual](MANUAL.md), or dicover the [ideas](#ideas) behind this specific tool.
@@ -175,3 +177,7 @@ Then, to make the release, run the following command:
     make release
 
 To only build the release zip, simply run `make dist`. This will create a zip file in `dist/` of the current version.
+
+[github status]: https://github.com/vincent-peugnet/wcms/workflows/build/badge.svg
+[code style]: https://img.shields.io/badge/code%20style-PSR12-brightgreen
+[phpstan level]: https://img.shields.io/badge/phpstan-level%205-green

--- a/app/class/Controllermedia.php
+++ b/app/class/Controllermedia.php
@@ -69,7 +69,7 @@ class Controllermedia extends Controller
             if (!empty($_FILES['file']['name'][0])) {
                 $this->mediamanager->multiupload('file', $target);
             }
-                $this->redirect($this->router->generate('media') . '?path=/' . $target);
+                $this->redirect($this->generate('media') . '?path=/' . $target);
         } else {
             $this->routedirect('home');
         }
@@ -82,7 +82,7 @@ class Controllermedia extends Controller
             $name = idclean($_POST['foldername']) ?? 'new-folder';
             $this->mediamanager->adddir($dir, $name);
         }
-        $this->redirect($this->router->generate('media') . '?path=/' . $dir . DIRECTORY_SEPARATOR . $name);
+        $this->redirect($this->generate('media') . '?path=/' . $dir . DIRECTORY_SEPARATOR . $name);
     }
 
     public function folderdelete()
@@ -91,11 +91,11 @@ class Controllermedia extends Controller
             if (isset($_POST['deletefolder']) && intval($_POST['deletefolder']) && $this->user->issupereditor()) {
                 $this->mediamanager->deletedir($_POST['dir']);
             } else {
-                $this->redirect($this->router->generate('media') . '?path=/' . $_POST['dir']);
+                $this->redirect($this->generate('media') . '?path=/' . $_POST['dir']);
                 exit;
             }
         }
-        $this->redirect($this->router->generate('media'));
+        $this->redirect($this->generate('media'));
     }
 
     public function edit()
@@ -107,6 +107,6 @@ class Controllermedia extends Controller
                 $this->mediamanager->multimovefile($_POST['id'], $_POST['dir']);
             }
         }
-        $this->redirect($this->router->generate('media') . '?path=/' . $_POST['path']);
+        $this->redirect($this->generate('media') . '?path=/' . $_POST['path']);
     }
 }

--- a/app/class/Logger.php
+++ b/app/class/Logger.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Wcms;
+
+use Throwable;
+
+/**
+ * Class used to log messages.
+ * It must be init once at the very beginning of the application.
+ */
+class Logger
+{
+    private static $file = null;
+    private static $verbosity = 4;
+
+    /**
+     * Initialize the logger by openning the file and setting the log level.
+     *
+     * @param string $path the logfile's path
+     * @param int $verbosity 0: no log, 1: errors only, 2: add warn, 3: add info, 4: add debug.
+     */
+    public static function init(string $path, int $verbosity = 4)
+    {
+        self::$file = fopen($path, "a") or die("Unable to open log file!");
+        self::$verbosity = $verbosity;
+    }
+
+    protected static function write(string $level, string $msg, array $args = [])
+    {
+        $caller = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2)[1];
+        $pwd = getcwd() . DIRECTORY_SEPARATOR;
+        $args = array_merge([
+            "[ $level ]",
+            str_replace($pwd, '', $caller['file']),
+            $caller['line']
+        ], $args);
+        vfprintf(self::$file, date('c') . " %-9s %s(%d) $msg\n", $args);
+    }
+
+    /**
+     * Log an error message using printf format.
+     */
+    public static function error(string $msg, ...$args)
+    {
+        if (self::$verbosity > 0) {
+            self::write('ERROR', $msg, $args);
+        }
+    }
+
+    /**
+     * Log a xarning message using printf format.
+     */
+    public static function warning(string $msg, ...$args)
+    {
+        if (self::$verbosity > 1) {
+            self::write('WARN', $msg, $args);
+        }
+    }
+
+    /**
+     * Log an info message using printf format.
+     */
+    public static function info(string $msg, ...$args)
+    {
+        if (self::$verbosity > 2) {
+            self::write('INFO', $msg, $args);
+        }
+    }
+
+    /**
+     * Log a debug message using printf format.
+     */
+    public static function debug(string $msg, ...$args)
+    {
+        if (self::$verbosity > 3) {
+            self::write('DEBUG', $msg, $args);
+        }
+    }
+
+    /**
+     * Log an exception.
+     */
+    public static function exception(Throwable $e, bool $withtrace = false)
+    {
+        if (self::$verbosity > 0) {
+            $msg = $e->getMessage();
+            if ($withtrace) {
+                // TODO: Maybe print a more beautiful stack trace.
+                $msg .= PHP_EOL . $e->getTraceAsString();
+            }
+            self::write('ERROR', $msg);
+        }
+    }
+}

--- a/app/class/Logger.php
+++ b/app/class/Logger.php
@@ -2,6 +2,7 @@
 
 namespace Wcms;
 
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -10,7 +11,7 @@ use Throwable;
  */
 class Logger
 {
-    private static $file = null;
+    private static $file = false;
     private static $verbosity = 4;
 
     /**
@@ -21,7 +22,18 @@ class Logger
      */
     public static function init(string $path, int $verbosity = 4)
     {
-        self::$file = fopen($path, "a") or die("Unable to open log file!");
+        if (!is_dir(dirname($path))) {
+            throw new InvalidArgumentException("Parent directory of '$path' does not exist.");
+        }
+        if (!is_writable(dirname($path))) {
+            throw new InvalidArgumentException("Parent directory of '$path' is not writable.");
+        }
+        if (is_file($path) && !is_writable($path)) {
+            throw new InvalidArgumentException("The logfile '$path' is not writable.");
+        }
+        self::$file = fopen($path, "a");
+        if (self::$file === false) {
+        }
         self::$verbosity = $verbosity;
     }
 

--- a/app/class/Modelrender.php
+++ b/app/class/Modelrender.php
@@ -56,7 +56,7 @@ class Modelrender extends Modelpage
      */
     public function upage(string $id): string
     {
-        return $this->router->generate('pageread/', ['page' => $id]);
+        return $this->generate('pageread/', ['page' => $id]);
     }
 
 

--- a/app/class/Routes.php
+++ b/app/class/Routes.php
@@ -3,11 +3,14 @@
 namespace Wcms;
 
 use AltoRouter;
+use Exception;
 
 class Routes
 {
     /**
      * Cherche une correspondance entre l'URL et les routes, et appelle la méthode appropriée
+     *
+     * @throws Exception if addRoutes fails (maybe it should be catched).
      */
     public function match()
     {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "autoload": {
         "psr-4": {
             "Wcms\\": "app/class"
-        }
+        },
+        "files": ["app/fn/fn.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {
+        "pepakriz/phpstan-exception-rules": "^0.10.1",
         "phpstan/phpstan": "^0.12.19",
         "phpunit/phpunit": "^8.5",
         "sentry/sdk": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     "require-dev": {
         "pepakriz/phpstan-exception-rules": "^0.10.1",
         "phpstan/phpstan": "^0.12.19",
+        "phpstan/phpstan-phpunit": "^0.12.8",
         "phpunit/phpunit": "^8.5",
         "sentry/sdk": "^2.0",
         "squizlabs/php_codesniffer": "^3.5"

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "w-cms",
+    "name": "w-cms/w-cms",
     "description": "point'n think",
     "require": {
         "php": ">=7.2.0",

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "michelf/php-markdown": "^1.8"
     },
     "require-dev": {
+        "phpstan/phpstan": "^0.12.19",
         "phpunit/phpunit": "^8.5",
         "sentry/sdk": "^2.0",
         "squizlabs/php_codesniffer": "^3.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "62366ccdb1bd41c988a46000a64bffd6",
+    "content-hash": "fa8ab175273737ddd7b8aed0ce7bc82f",
     "packages": [
         {
             "name": "altorouter/altorouter",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a0cc5da0ce5a7eec0d4fdc30087dd9b",
+    "content-hash": "b26e62f8b85c611f3db528f8690e4dfe",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -1436,6 +1436,48 @@
                 "stub"
             ],
             "time": "2020-03-05T15:02:03+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "0.12.19",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
+                "reference": "054f6d76b12ba9a6c13a5a8d5fcdf51219615f4d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "time": "2020-04-19T20:35:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "78878874876578b163daba4b9d866b23",
+    "content-hash": "62366ccdb1bd41c988a46000a64bffd6",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -1532,6 +1532,62 @@
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "time": "2020-04-19T20:35:10+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "0.12.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "7232c17e2493dc598173da784477ce0afb2c4e0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/7232c17e2493dc598173da784477ce0afb2c4e0e",
+                "reference": "7232c17e2493dc598173da784477ce0afb2c4e0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.1",
+                "phpstan/phpstan": "^0.12.6"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "consistence/coding-standard": "^3.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "ergebnis/composer-normalize": "^2.0.2",
+                "jakub-onderka/php-parallel-lint": "^1.0",
+                "phing/phing": "^2.16.0",
+                "phpstan/phpstan-strict-rules": "^0.12",
+                "phpunit/phpunit": "^7.0",
+                "satooshi/php-coveralls": "^1.0",
+                "slevomat/coding-standard": "^4.7.2"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.12-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "time": "2020-04-17T08:04:10+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26e62f8b85c611f3db528f8690e4dfe",
+    "content-hash": "78878874876578b163daba4b9d866b23",
     "packages": [
         {
             "name": "altorouter/altorouter",
@@ -696,6 +696,60 @@
                 "random"
             ],
             "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "pepakriz/phpstan-exception-rules",
+            "version": "v0.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pepakriz/phpstan-exception-rules.git",
+                "reference": "7073711906e22509cbfacbca0a914e0f8ff2e6c8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pepakriz/phpstan-exception-rules/zipball/7073711906e22509cbfacbca0a914e0f8ff2e6c8",
+                "reference": "7073711906e22509cbfacbca0a914e0f8ff2e6c8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1",
+                "phpstan/phpstan": "^0.12.0"
+            },
+            "require-dev": {
+                "jakub-onderka/php-console-highlighter": "0.4.0",
+                "jakub-onderka/php-parallel-lint": "1.0.0",
+                "nette/utils": "^3.0",
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpstan/phpstan": "^0.12.0",
+                "phpstan/phpstan-nette": "^0.12.0",
+                "phpstan/phpstan-phpunit": "^0.12.0",
+                "phpstan/phpstan-strict-rules": "^0.12.0",
+                "phpunit/phpunit": "^7.5.6",
+                "slevomat/coding-standard": "^5.0.4",
+                "squizlabs/php_codesniffer": "~3.5.2"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.10-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pepakriz\\PHPStanExceptionRules\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Exception rules for PHPStan",
+            "time": "2019-12-09T06:14:56+00:00"
         },
         {
             "name": "phar-io/manifest",

--- a/index.php
+++ b/index.php
@@ -3,10 +3,6 @@
 session_start();
 
 
-
-require('app/fn/fn.php');
-
-
 require('./vendor/autoload.php');
 
 

--- a/index.php
+++ b/index.php
@@ -26,7 +26,7 @@ if (isreportingerrors()) {
 try {
     $matchoper = new Wcms\Routes();
     $matchoper->match();
-} catch (Exception $e) {
+} catch (Throwable $e) {
     if (isreportingerrors()) {
         Sentry\captureException($e);
     }

--- a/index.php
+++ b/index.php
@@ -1,10 +1,13 @@
 <?php
 
+use Wcms\Logger;
+
 session_start();
 
 
 require('./vendor/autoload.php');
 
+Logger::init('w_error.log', 2);
 
 $app = new Wcms\Application();
 $app->wakeup();
@@ -30,5 +33,6 @@ try {
     if (isreportingerrors()) {
         Sentry\captureException($e);
     }
+    Logger::exception($e, true);
     echo '<h1>⚠ Woops ! There is a little problem : </h1>', $e->getMessage(), "\n";
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,5 @@
 includes:
+    - vendor/phpstan/phpstan-phpunit/extension.neon
     - vendor/pepakriz/phpstan-exception-rules/extension.neon
 
 parameters:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,7 @@
+parameters:
+    level: 5
+    paths:
+        - app/class
+        - app/fn
+        - index.php
+        - tests

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,6 +10,7 @@ parameters:
         - index.php
         - tests
     exceptionRules:
+        ignoreDescriptiveUncheckedExceptions: true
         # ignore some exceptions and their chlidrens
         uncheckedExceptions:
             - Error

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,6 @@
+includes:
+    - vendor/pepakriz/phpstan-exception-rules/extension.neon
+
 parameters:
     level: 5
     paths:
@@ -5,3 +8,11 @@ parameters:
         - app/fn
         - index.php
         - tests
+    exceptionRules:
+        # ignore some exceptions and their chlidrens
+        uncheckedExceptions:
+            - Error
+            - LogicException
+        # ignore all exceptions errors in tests classes
+        methodWhitelist:
+            PHPUnit\Framework\TestCase: '#.*#i'

--- a/tests/FilesTest.php
+++ b/tests/FilesTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Wcms\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * This abstract test class adds 3 usefull variables for files tests:
+ * - $this->testdir
+ * - $this->notwritabledir
+ * - $this->notwritablefile
+ */
+abstract class FilesTest extends TestCase
+{
+    protected $testdir = 'build/test';
+    protected $notwritabledir = 'build/test/notwritabledir';
+    protected $notwritablefile = 'build/test/notwritablefile';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!is_dir($this->testdir)) {
+            mkdir($this->testdir, 0755, true);
+        }
+        if (!file_exists($this->notwritabledir)) {
+            mkdir($this->notwritabledir, 0000);
+        }
+        if (!file_exists($this->notwritablefile)) {
+            touch($this->notwritablefile);
+            chmod($this->notwritablefile, 0000);
+        }
+    }
+}

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Wcms\Tests;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+use Wcms\Logger;
+
+class LoggerTest extends TestCase
+{
+    protected $logfile = 'build/w_error.log';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (file_exists($this->logfile)) {
+            unlink($this->logfile);
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function initTest(): void
+    {
+        Logger::init($this->logfile);
+        $this->assertFileExists($this->logfile, 'Log file has not been created.');
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    /**
+     * @test
+     * @dataProvider errorNotLoggedProvider
+     */
+    public function errorNotLoggedTest(int $verbosity): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::error('Error.');
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    public function errorNotLoggedProvider(): array
+    {
+        return [[0]];
+    }
+
+    /**
+     * @test
+     * @dataProvider errorLoggedProvider
+     */
+    public function errorLoggedTest(int $verbosity, string $msg, array $args, string $expected): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::error($msg, ...$args);
+        $expected = " [ ERROR ] tests/LoggerTest.php(55) $expected\n";
+        $this->assertEquals($expected, substr(file_get_contents($this->logfile), 25));
+    }
+
+    public function errorLoggedProvider(): array
+    {
+        return [
+            [1, 'Error %s.', ['test'], 'Error test.'],
+            [2, 'Error %s %d.', ['test', 2], 'Error test 2.'],
+            [3, 'Error.', [], 'Error.'],
+            [4, 'Error.', [], 'Error.'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider warningNotLoggedProvider
+     */
+    public function warningNotLoggedTest(int $verbosity): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::warning('Error.');
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    public function warningNotLoggedProvider(): array
+    {
+        return [[0], [1]];
+    }
+
+    /**
+     * @test
+     * @dataProvider warningLoggedProvider
+     */
+    public function warningLoggedTest(int $verbosity, string $msg, array $args, string $expected): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::warning($msg, ...$args);
+        $expected = " [ WARN ]  tests/LoggerTest.php(93) $expected\n";
+        $this->assertEquals($expected, substr(file_get_contents($this->logfile), 25));
+    }
+
+    public function warningLoggedProvider(): array
+    {
+        return [
+            [2, 'Error %s.', ['test'], 'Error test.'],
+            [3, 'Error.', [], 'Error.'],
+            [4, 'Error.', [], 'Error.'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider infoNotLoggedProvider
+     */
+    public function infoNotLoggedTest(int $verbosity): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::info('Error.');
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    public function infoNotLoggedProvider(): array
+    {
+        return [[0], [1], [2]];
+    }
+
+    /**
+     * @test
+     * @dataProvider infoLoggedProvider
+     */
+    public function infoLoggedTest(int $verbosity, string $msg, array $args, string $expected): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::info($msg, ...$args);
+        $expected = " [ INFO ]  tests/LoggerTest.php(130) $expected\n";
+        $this->assertEquals($expected, substr(file_get_contents($this->logfile), 25));
+    }
+
+    public function infoLoggedProvider(): array
+    {
+        return [
+            [3, 'Error %s.', ['test'], 'Error test.'],
+            [4, 'Error.', [], 'Error.'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider debugNotLoggedProvider
+     */
+    public function debugNotLoggedTest(int $verbosity): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::debug('Error.');
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    public function debugNotLoggedProvider(): array
+    {
+        return [[0], [1], [2], [3]];
+    }
+
+    /**
+     * @test
+     * @dataProvider debugLoggedProvider
+     */
+    public function debugLoggedTest(int $verbosity, string $msg, array $args, string $expected): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::debug($msg, ...$args);
+        $expected = " [ DEBUG ] tests/LoggerTest.php(166) $expected\n";
+        $this->assertEquals($expected, substr(file_get_contents($this->logfile), 25));
+    }
+
+    public function debugLoggedProvider(): array
+    {
+        return [
+            [4, 'Error %s.', ['test'], 'Error test.'],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider exceptionNotLoggedProvider
+     */
+    public function exceptionNotLoggedTest(int $verbosity): void
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::exception(new Exception('Error'));
+        $this->assertEmpty(file_get_contents($this->logfile));
+    }
+
+    public function exceptionNotLoggedProvider(): array
+    {
+        return [[0]];
+    }
+
+    /**
+     * @test
+     * @dataProvider exceptionLoggedProvider
+     */
+    public function exceptionLoggedTest(int $verbosity, Throwable $e, string $expected)
+    {
+        Logger::init($this->logfile, $verbosity);
+        Logger::exception($e);
+        $expected = " [ ERROR ] tests/LoggerTest.php(201) $expected\n";
+        $this->assertEquals($expected, substr(file_get_contents($this->logfile), 25));
+    }
+
+    public function exceptionLoggedProvider(): array
+    {
+        return [
+            [1, new Exception('Test 1'), 'Test 1'],
+            [2, new Exception('Test 2'), 'Test 2'],
+            [3, new Exception('Test 3'), 'Test 3'],
+            [4, new Exception('Test 4'), 'Test 4'],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionBacktraceTest(): void
+    {
+        Logger::init($this->logfile, 1);
+        Logger::exception(new Exception('Error'), true);
+        $content = file_get_contents($this->logfile);
+        $expected = " [ ERROR ] tests/LoggerTest.php(222) Error\n";
+        $this->assertEquals($expected, substr($content, 25, 43));
+        $this->assertRegExp('/(#\d+ [\w\/\.]*\(\d+\): .*\)\n)+#\d+ \{main\}\n/U', substr($content, 68));
+    }
+}


### PR DESCRIPTION
Once again there is a [vscode extension for phpstan](https://marketplace.visualstudio.com/items?itemName=Mandy91.vscode-phpstan). The only problem with it is that it doesn't read the level from the config file so you have to set it in vscode config:
```json
    "phpstan.level": "5"
```
I add a phpstan extension for phpunit (I don't remember exactly what it adds). And also another one more important that checks all the Exception stuff, which is great. But there is one more thing to understand about exceptions. It's quite well explained on te [extension github repo](https://github.com/pepakriz/phpstan-exception-rules#motivation).

This is because of this Exception extension that I added  fb4eca8 and daec2ee. The first one is an exemple of refactoring that transform an `Exception` into a `LogicException`. And the second one is a logger class to log the catched errors (as, for now, these are not logged anywhere).

I also added a commit to run all the checks on github each time you push to master, this is not eating bread.

Closes #96 