### PR TITLE
fix(render): remove added media class

### DIFF
--- a/app/class/Modelrender.php
+++ b/app/class/Modelrender.php
@@ -359,7 +359,7 @@ class Modelrender extends Modelpage
     public function media(string $text): string
     {
         $regex = '%(src|href)="([\w\-]+(\/([\w\-])+)*\.[a-z0-9]{1,5})"%';
-        $text = preg_replace($regex, '$1="' . Model::mediapath() . '$2" target="_blank" class="media"', $text);
+        $text = preg_replace($regex, '$1="' . Model::mediapath() . '$2" target="_blank"', $text);
         if (!is_string($text)) {
             //throw new Exception('Rendering error -> media module');
         }


### PR DESCRIPTION
This class is IMO not usefull as we already have the img selector to
select all the medias in the page (or we can even select img and a).
On the other hand, adding this class overrides the ones we can add with
markdown extra's syntax: {.custom-class}.