### PR TITLE
feat: reuse the same tab for each click on display

### DIFF
--- a/app/view/templates/edittopbar.php
+++ b/app/view/templates/edittopbar.php
@@ -17,7 +17,7 @@
 
 
 
-    <a href="<?= $this->upage('pageread/', $page->id()) ?>" target="_blank" id="display">
+    <a href="<?= $this->upage('pageread/', $page->id()) ?>" target="<?= $page->id() ?>" id="display">
         <img src="<?= Wcms\Model::iconpath() ?>read.png" class="icon">
         <span class="hidephone">display</span>
     </a>


### PR DESCRIPTION
I'm often using <kbd>ctrl</kbd> + <kbd>s</kbd>, <kbd>ctrl</kbd> + <kbd>d</kbd> to quickly display the result of my changes. But by doing this a new tab is opened each time.
This change makes the browser reuse the same tab each time the display button is clicked
