### PR TITLE
fix: remove old sentry option

### DIFF
--- a/index.php
+++ b/index.php
@@ -26,7 +26,6 @@ if (isreportingerrors()) {
     Sentry\init([
         'dsn' => Wcms\Config::sentrydsn(),
         'release' => getversion(),
-        'project_root' => 'app',
     ]);
     Sentry\configureScope(function ($scope) {
         $scope->setUser([


### PR DESCRIPTION
there is no help about it in the migration doc : https://github.com/getsentry/sentry-php/blob/master/UPGRADE-3.0.md
