### PR TITLE
feat: catch http errors and display error

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -242,10 +242,14 @@ function submitHandler(form) {
     var fd = new FormData(form);
 
     xhr.addEventListener('load', function(event) {
-        saved();
+        if (httpOk(xhr.status)) {
+            saved();
+        } else {
+            alert('Error while trying to update: ' + xhr.statusText);
+        }
     });
     xhr.addEventListener('error', function(event) {
-        alert('Error while trying to update.');
+        alert('Network error while trying to update.');
     });
     xhr.open(form.method, form.action);
     xhr.send(fd);
@@ -271,4 +275,12 @@ function saved() {
     unsavedChanges = false;
     document.title = '✏ ' + pagetitle;
     document.getElementById('headid').innerHTML = pageid;
+}
+
+/**
+ * Check if an HTTP response status indicates a success.
+ * @param {number} status
+ */
+function httpOk(status) {
+    return status >= 200 && status < 300;
 }


### PR DESCRIPTION
allows to differentiate between network error:
![2022-01-13-130218_444x169_scrot](https://user-images.githubusercontent.com/23519418/149327016-2add671c-ff11-427a-a961-9eac3be737cd.png)

and http error (example with [`http_response_code(409)`](https://www.php.net/manual/en/function.http-response-code.php) in the controller):
![2022-01-13-130146_443x194_scrot](https://user-images.githubusercontent.com/23519418/149327048-25565c2c-3450-4e62-98e3-fc44bc7c2a5e.png)

