### PR TITLE
fix: media should not have target property

### DIFF
--- a/app/class/Modelrender.php
+++ b/app/class/Modelrender.php
@@ -389,7 +389,7 @@ class Modelrender extends Modelpage
     public function media(string $text): string
     {
         $regex = '%(src|href)="([\w\-]+(\/([\w\-])+)*\.[a-z0-9]{1,5})"%';
-        $text = preg_replace($regex, '$1="' . Model::mediapath() . '$2" target="_blank"', $text);
+        $text = preg_replace($regex, '$1="' . Model::mediapath() . '$2"', $text);
         if (!is_string($text)) {
             //throw new Exception('Rendering error -> media module');
         }


### PR DESCRIPTION
Fixes `Error: Attribute target not allowed on element img at this point.` 

see: https://validator.nu/?doc=http://club1.fr/nouveau-boitier/&schema=http://s.validator.nu/html5-rdfalite.rnc+http://s.validator.nu/html5/assertions.sch+http://c.validator.nu/all/
