### PR TITLE
ci: fix and test phpstan with php 8.0+

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        php: ['7.4', '8.0']
+        php: ['7.4', '8.0', '8.1']
         include:
         - os: windows-latest
           php: '7.4'
@@ -119,4 +119,37 @@ jobs:
 
       - name: PHPStan
         if: always()
+        run: make analyse
+
+  analyse:
+    name: analyse php 8.1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: '8.1'
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: make vendor
+
+      - name: PHPStan
         run: make analyse

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -44,7 +44,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: make vendor
 
       - name: PHPUnit
         run: |
@@ -108,7 +108,7 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: make vendor
 
       - name: PHPCS
         if: always()
@@ -119,4 +119,4 @@ jobs:
 
       - name: PHPStan
         if: always()
-        run: vendor/bin/phpstan analyse --no-progress
+        run: make analyse

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ PREV_ENV                := $(strip $(shell cat $(PREV_ENV_FILE) 2>/dev/null))
 HOST                    := localhost
 PORT                    := 8080
 PHP_FLAGS               += $(and $(XDEBUG3),-d xdebug.start_with_request=yes)
+PHPSTAN_FLAGS           += $(and $(CI),--no-progress)
+COMPOSER_FLAGS          += $(and $(CI),--prefer-dist --no-progress)
 
 # Files variables.
 js_sources  := $(wildcard $(js_src_dir)/*.js)
@@ -199,7 +201,7 @@ fix: $(phpcs_dir) vendor
 # Analyse php code with phpstan.
 .PHONY: analyse
 analyse: vendor
-	phpstan analyse
+	phpstan analyse $(PHPSTAN_FLAGS)
 
 # Test php code with phpunit.
 .PHONY: test

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,13 +5,11 @@ includes:
 parameters:
     level: 5
     paths:
-        - app/class
-        - app/fn
+        - app
         - index.php
         - tests
     excludePaths:
         - app/view/*
-        - vendor/*
     exceptionRules:
         # ignore some exceptions and their chlidrens
         uncheckedExceptions:


### PR DESCRIPTION
- ci: use more make, to make sure scripts run locally using make pass the CI correctly
- ci: add PHP 8.1 to tests and phpstan
- fix: phpstan config for php 8.0+ by removing useless config

