### PR TITLE
rss: add xml:lang attributes to englobing elements

### DIFF
--- a/app/class/Servicerss.php
+++ b/app/class/Servicerss.php
@@ -76,6 +76,7 @@ class Servicerss
 
         $feed = $xml->createElement('feed');
         $feed->setAttribute("xmlns", "http://www.w3.org/2005/Atom");
+        $feed->setAttribute('xml:lang', Config::lang());
 
         $title = $xml->createElement("title");
         $title->appendChild(new DOMText($bookmark->name()));
@@ -128,6 +129,9 @@ class Servicerss
 
         foreach ($pagelist as $page) {
             $entry = $xml->createElement("entry");
+            if (!empty($page->lang())) {
+                $entry->setAttribute('xml:lang', $page->lang());
+            }
             $feed->appendChild($entry);
 
             $title = $xml->createElement("title");


### PR DESCRIPTION
Based on the default language value and the page's own language value.
[RFC4287 section 2](https://datatracker.ietf.org/doc/html/rfc4287#section-2):

> Any element defined by this specification MAY have an xml:lang
> attribute, whose content indicates the natural language for the
> element and its descendents.  The language context is only
> significant for elements and attributes declared to be "Language-
> Sensitive" by this specification.

The validity of the resulting document has been tested using <https://validator.w3.org/feed/>.
