### PR TITLE
smaller and landscape ratio map by default

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -127,7 +127,7 @@ span.redirection {
 
 div#geomap {
     width: 800px;
-    height: 800px;
+    height: 570px;
 }
 
 


### PR DESCRIPTION
mostly to fix the center on smaller screens, this is more of a warkaround and should be handled better in css, maybe using viewport height and width values instead of hard px ones.
