### PR TITLE
update set-output usage

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -33,7 +33,8 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -97,7 +98,8 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -159,7 +161,8 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
see: <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>
