### PR TITLE
Reload preview window instead of changing location

### DIFF
--- a/src/edit.js
+++ b/src/edit.js
@@ -24,6 +24,9 @@ import shadow from 'leaflet/dist/images/marker-shadow.png';
 import * as L from 'leaflet';
 import { initWorkspaceForm, submitHandler } from './fn/fn';
 
+/** @var {Window | null} */
+let preview = null;
+
 /* ________________ TAGIFY  ________________ */
 
 /** @var {HTMLInputElement} */
@@ -450,7 +453,11 @@ function keyboardHandler(e) {
                     const a = document.getElementById('display');
                     const href = a.getAttribute('href');
                     const target = a.getAttribute('target');
-                    window.open(href, target);
+                    try {
+                        preview.location.reload();
+                    } catch {
+                        preview = window.open(href, target);
+                    }
                     break;
                 default:
                     return true;


### PR DESCRIPTION
This allow to stay at the same place in the previewed page after the render refresh. For now it is only working with Ctrl + D, not when clicking the button, as the button is only a simple link. Later the button could be overriden with javascript to allow the same behaviour
