### PR TITLE
Add parallel PHP syntax check on template files

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,7 +112,10 @@ jobs:
       - name: Install dependencies
         run: make vendor
 
-      - name: PHPCS
+      - name: Lint templates
+        run: make lint-templates
+
+      - name: Lint app
         if: always()
         run: |
           echo "::add-matcher::.github/matchers/phpcs.json"

--- a/Makefile
+++ b/Makefile
@@ -173,11 +173,18 @@ check: lint analyse test
 .PHONY: lint
 lint: lint-php lint-js
 
-# Lint php code with phpcs.
+# Lint php code.
 .PHONY: lint-php
-lint-php: $(phpcs_dir) vendor
+lint-php: lint-templates lint-app
+
 # Run PHP syntax check on template files in parallel thanks to xargs
+.PHONY: lint-templates
+lint-templates:
 	echo app/view/templates/*.php | xargs -P$(NPROC) -n1 php --syntax-check > /dev/null
+
+# Lint backend php code with phpcs.
+.PHONY: lint-app
+lint-app: $(phpcs_dir) vendor
 	phpcs --report-full --report-summary --cache=$(phpcs_dir)/result.cache || { printf "run 'make fix'\n\n"; exit 1; }
 
 .PHONY: lint-js


### PR DESCRIPTION
Before this, absolutely no automated checks were done on template files now we at least ensure that they are valid PHP files.

The parallel run should work correctly on macOS and other Unix-like systems. On Windows, we fallback to sequential execution.

This takes around 1 second on my not so fast 2/4 cores Intel laptop.