### PR TITLE
workspace menu is always in hbar-section, fix #480

### DIFF
--- a/app/view/templates/homemenu.php
+++ b/app/view/templates/homemenu.php
@@ -523,6 +523,9 @@
                 <?php endif ?>
             </div>
         </details>
+    </div>
+
+    <div class="hbar-section">
 
         <div id="save-workspace">
             <form

--- a/app/view/templates/mediamenu.php
+++ b/app/view/templates/mediamenu.php
@@ -142,6 +142,9 @@
                 </form>
             </div>
         </details>
+    </div>
+
+    <div class="hbar-section">
 
         <div id="save-workspace">
             <form

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -18,7 +18,6 @@ topbar
 navbar 
 toggle panels (collapsibles) 
 delete 
-workspace button (no-js) 
 media queries 
 flash messages 
 
@@ -492,14 +491,6 @@ input.toggle-panel-toggle {
     padding: var(--spacing);
 }
 
-/* --------------------------------------------------------- workspace button (no-js) */
-#save-workspace {
-    position: absolute;
-    right: var(--spacing);
-}
-.js #save-workspace {
-    display: none;
-}
 /* --------------------------------------------------------- media queries */
 
 

--- a/src/fn/fn.js
+++ b/src/fn/fn.js
@@ -91,11 +91,9 @@ export function initWorkspaceForm() {
     for (const input of inputs) {
         input.oninput = workspaceChanged;
     }
-    let submits = form.querySelectorAll('[type="submit"]');
-    for (const submit of submits) {
-        if (submit instanceof HTMLElement) {
-            submit.style.display = 'none';
-        }
+    let saveworkspace = document.getElementById('save-workspace');
+    if (saveworkspace instanceof HTMLElement) {
+        saveworkspace.style.display = 'none';
     }
 
     form.addEventListener('submit', function(event) {


### PR DESCRIPTION
- remove home specific absolute positioning
- remove unused "hide in case of js" css

@jbidoret : this is how I would do it.

You tell me if it's ok for you ! 😃

I don't see the problem when only the button is `display:none`. 🤔 maybe because I did'nt checked all the themes!
Anyway, since with this PR, `<form>` is always inside a `hbar-section`, it can be hidden without breaking the flex positioning.