### PR TITLE
Fix codemirror search bar

### DIFF
--- a/assets/css/edit.css
+++ b/assets/css/edit.css
@@ -97,7 +97,7 @@ div#geomap {
     margin-left: 1.75em;
 }
 
-.tab label {
+.tab>label {
 	display: inline-block;
     position: relative;
     padding: var(--half-spacing) var(--spacing) calc(var(--spacing) + var(--half-spacing));
@@ -109,7 +109,7 @@ div#geomap {
 }
 
 /* if the tab contains anything */
-.tab label.edited {
+.tab>label.edited {
     text-decoration: underline;
     text-decoration-style: dashed;
     text-decoration-color: color-mix(in srgb, var(--text2-color) 70%, var(--main-color) 30%);
@@ -117,7 +117,7 @@ div#geomap {
 }
 
 /* @todo: report an issue: $templates[$key] never returns anything */
-.tab label.template {
+.tab>label.template {
     color: var(--text2-color);
 }
 


### PR DESCRIPTION
The codemirror searchbar was inheriting CSS from the tab bar, which broke it.

### Before
![2025-06-14-171934_553x395_scrot](https://github.com/user-attachments/assets/3db6fb1e-5635-4ca0-9ab5-2f58a6001c82)

### After
![2025-06-14-171749_589x381_scrot](https://github.com/user-attachments/assets/f2984bbf-2597-47d6-9294-a204a5a4d1d9)

